### PR TITLE
Add reference to github repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infobox-parser",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Parse Wikipedia Infobox Source",
   "main": "build/bundle.min.js",
   "scripts": {
@@ -9,6 +9,13 @@
   },
   "author": "Richard van der Dys",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dijs/infobox-parser"
+  },
+  "bugs": {
+    "url": "https://github.com/dijs/infobox-parser/issues"
+  },
   "devDependencies": {
     "babel-core": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
Just found the project on npm, but took me a few clicks to find the repo on github. This will make npm to add the link to github.