### PR TITLE
Point number format problem

### DIFF
--- a/test/dublin-spec.js
+++ b/test/dublin-spec.js
@@ -2,7 +2,7 @@ require('should');
 import fs from 'fs';
 import parse from '../index';
 
-describe.only('Should Parse Dublins\'s Information', () => {
+describe('Should Parse Dublins\'s Information', () => {
   const source = fs.readFileSync('./data/dublin.txt', 'utf8');
   const properties = parse(source, { simplifyDataValues: false });
   it('Population Total', () => {

--- a/test/dublin-spec.js
+++ b/test/dublin-spec.js
@@ -2,9 +2,13 @@ require('should');
 import fs from 'fs';
 import parse from '../index';
 
-describe('Should Parse Dublins\'s Information', () => {
+describe.only('Should Parse Dublins\'s Information', () => {
   const source = fs.readFileSync('./data/dublin.txt', 'utf8');
   const properties = parse(source, { simplifyDataValues: false });
+  it('Population Total', () => {
+    properties.should.have.property('populationTotal');
+    properties.populationTotal.should.equal(553165);
+  });
   it('GDP Per Capita blank data', () => {
     properties.should.have.property('gdpPerCapita', 'US$ 51,319');
   });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--recursive
+--compilers js:babel-core/register

--- a/test/util/numberParse.js
+++ b/test/util/numberParse.js
@@ -1,0 +1,43 @@
+import parse from '../../util/numberParse'
+
+const tests = {
+
+  // English format cases
+       '1111'     : 1111,
+      '1,111'     : 1111,
+  '1,111,111'     : 1111111,
+  '1,111,111.11'  : 1111111.11,
+      '1,111.11'  : 1111.11,
+       '1111.11'  : 1111.11,
+         '11.11'  : 11.11,
+          '1.1111': 1.1111,
+
+  // Spanish format cases
+      '1.111'     : 1111,
+  '1.111.111'     : 1111111,
+  '1.111.111,11'  : 1111111.11,
+      '1.111,11'  : 1111.11,
+       '1111,11'  : 1111.11,
+         '11,11'  : 11.11,
+          '1,1111': 1.1111,
+
+  // If whitespaces
+  '1 111 111.11'  : 1111111.11,
+  '1 111 111,11'  : 1111111.11,
+
+  // Not numbers
+  '$100': false,
+  'wiki': false,
+  '100 $': false,
+  '': false
+}
+
+describe('Number Parser', () => {
+
+  Object.keys(tests).forEach((str) => {
+    it(`parses ${str}`, () => {
+      parse(str).should.equal(tests[str])
+    })
+  })
+})
+

--- a/util/extractProperties.js
+++ b/util/extractProperties.js
@@ -85,7 +85,8 @@ function reduceVariable(key, value, context, options) {
     return value.map(item => getVariableValue(item, context, options));
   }
   if (key.match(/areaTotal/) || key.match(/population/)) {
-    const float = numberParse(value)
+    let float = numberParse(value);
+    if (float === false) float = parseFloat(value, 10);
     if (!isNaN(float)) {
       return float;
     }

--- a/util/extractProperties.js
+++ b/util/extractProperties.js
@@ -84,6 +84,8 @@ function reduceVariable(key, value, context, options) {
     return value.map(item => getVariableValue(item, context, options));
   }
   if (key.match(/areaTotal/) || key.match(/population/)) {
+    //TODO check if the number has commas or point separator, and
+    //consider the language for the formatting
     const float = parseFloat(value, 10);
     if (!isNaN(float)) {
       return float;

--- a/util/extractProperties.js
+++ b/util/extractProperties.js
@@ -1,5 +1,6 @@
 import dataTypes from '../data-types/index';
 import findPropertyList from './propertyList';
+import numberParse from './numberParse'
 
 const smallDataType = dataTypes.find(type => type.name === 'smalls');
 
@@ -84,9 +85,7 @@ function reduceVariable(key, value, context, options) {
     return value.map(item => getVariableValue(item, context, options));
   }
   if (key.match(/areaTotal/) || key.match(/population/)) {
-    //TODO check if the number has commas or point separator, and
-    //consider the language for the formatting
-    const float = parseFloat(value, 10);
+    const float = numberParse(value)
     if (!isNaN(float)) {
       return float;
     }

--- a/util/numberParse.js
+++ b/util/numberParse.js
@@ -1,0 +1,73 @@
+
+/**
+ * Given a string meant to contain a number, tries to find out
+ * the number considering comma or point separators
+ * @param  {String} number
+ * @return {Number} with the parsed number, false, if the parsing is
+ *                  not possible
+ */
+export default (number) => {
+
+  if (typeof number !== 'string') return false
+
+  number = number.trim().replace(/ /g, '')
+
+  // Find out if commas are using as thousand or decimal separators.
+  // If the string has both, and commas are first, then commas are
+  // thousand separators (english style)
+  if (number.match(/,/) && number.match(/\./)) {
+    if (number.indexOf(',') < number.indexOf('.')) {
+      return parseEnglish(number)
+    } else {
+      return parseSpanish(number)
+    }
+  }
+
+  if (number.match(/,/) && !number.match(/\./)) {
+    if (number.match(/,/g).length > 1) {
+
+      // If there is more than one, then it's a thousand separator
+      return parseEnglish(number)
+    } else {
+
+      // If it's follwed by 3 digits, it's proably a thousand separator
+      if (number.match(/,[0-9]{3}($|^[0-9])/)) {
+        return parseEnglish(number)
+      } else {
+        return parseSpanish(number)
+      }
+
+    }
+  }
+
+  if (!number.match(/,/) && number.match(/\./)) {
+    if (number.match(/\./g).length > 1) {
+
+      // If there is more than one, then it's a thousand separator
+      return parseSpanish(number)
+    } else {
+
+      // If it's follwed by 3 digits, it's proably a thousand separator
+      if (number.match(/\.[0-9]{3}($|^[0-9])/)) {
+        return parseSpanish(number)
+      } else {
+        return parseEnglish(number)
+      }
+
+    }
+  }
+
+  // If it looks the same as number or string, just cast it
+  if ((+number).toString() === number) return +number
+
+  return false
+}
+
+const parseEnglish = (str) => {
+  return +str.replace(/,/g, '')
+}
+
+const parseSpanish = (str) => {
+  return +str.replace(/\./g, '').replace(/,/g, '.')
+}
+

--- a/util/numberParse.js
+++ b/util/numberParse.js
@@ -12,7 +12,7 @@ export default (number) => {
 
   number = number.trim().replace(/ /g, '')
 
-  // Find out if commas are using as thousand or decimal separators.
+  // Find out if commas are used as thousand or decimal separators.
   // If the string has both, and commas are first, then commas are
   // thousand separators (english style)
   if (number.match(/,/) && number.match(/\./)) {


### PR DESCRIPTION
If a number has comma separators, like the case for `populationTotal` in the Dublin test, it doesn't parse well.

This PR adds a test revealing the problem.

The problem is even more complex, since the parser would need to consider the language of the page, to determine if the comma stands as thousand separator, or decimal separator. For example, the JS number 5000.05, would be formatted '5,000.05' in English, but '5.000,05' in Spanish. I point this, because my first solution was to just remove the commas before the parseInt(), but it doesn't work when the page is in Spanish.

Maybe a solution could be to just always return strings, and delegate the responsibility of casting to the user of the module. (which would still be me :laughing: , but at least I know when I am requesting the page in english or spanish, so I can decide to cast the number considering english or spanish format)