### PR TITLE
Adding data type for unbulleted lists

### DIFF
--- a/data-types/index.js
+++ b/data-types/index.js
@@ -2,6 +2,7 @@ import small from './small';
 import flag from './flag';
 import coords from './coords';
 import instances from './instances';
+import unbulletedLists from './unbulletedLists';
 import unmarkedLists from './unmarkedLists';
 import plainLists from './plainLists';
 import marriages from './marriages';
@@ -18,6 +19,7 @@ const dataTypes = [
   coords,
   marriages,
   birthDates,
+  unbulletedLists,
   url,
   // other needs to always be after specific data dypes
   other,

--- a/data-types/unbulletedLists.js
+++ b/data-types/unbulletedLists.js
@@ -1,0 +1,20 @@
+import getValue from '../util/getValue';
+
+const listItemPrefixPattern = /^\|\s?/;
+const unbulletedListGlobalPattern = /\{\{(?:unbulleted list|ubl|ubt|ublist|unbullet)\s?\|([^\}\}]+)\}\}/g;
+const unbulletedListItemPattern = /\|\s*([^|}]+)/g;
+
+export default {
+  globalPattern: unbulletedListGlobalPattern,
+  parsePattern: unbulletedListItemPattern,
+  parse: listItems => {
+    if (!listItems) {
+      return [];
+    }
+    return listItems
+      .map(item => item.replace(listItemPrefixPattern, '').trim())
+      .filter(value => value && value.length);
+  },
+  variable: 'UNBULLETED_LIST',
+  name: 'unbulletedLists',
+};

--- a/data/the-lego-batman-movie.txt
+++ b/data/the-lego-batman-movie.txt
@@ -1,0 +1,54 @@
+{{Infobox film
+| name                 = The Lego Batman Movie
+| image                = The Lego Batman Movie PromotionalPoster.jpg
+| alt                  = 
+| caption              = Theatrical release poster
+| director             = [[Chris McKay]]
+| producers            = {{plainlist|
+* [[Dan Lin]]
+* [[Roy Lee]]
+* [[Phil Lord and Christopher Miller|Phil Lord]]
+* [[Phil Lord and Christopher Miller|Christopher Miller]]
+}}
+| screenplay              = {{plainlist|
+* [[Seth Grahame-Smith]]
+* [[Chris McKenna (writer)|Chris McKenna]]
+* Erik Sommers
+* Jared Stern
+* John Whittington
+}}
+| story              = Seth Grahame-Smith
+| based on             = {{Plainlist|
+* Characters<br />by [[DC Comics]]
+* [[Lego|Lego Construction Toys]]
+}}
+| starring             = {{plainlist|
+* [[Will Arnett]]
+* [[Zach Galifianakis]]
+* [[Michael Cera]]
+* [[Rosario Dawson]]
+* [[Ralph Fiennes]]
+}}
+| music             =[[Lorne Balfe]]<ref name="lorne-balfe-fmr">{{cite news|title=Lorne Balfe to Score ‘The Lego Batman Movie’|url=http://filmmusicreporter.com/2016/06/09/lorne-balfe-to-score-the-lego-batman-movie/|accessdate=June 9, 2016|work=Film Music Reporter|publisher=Film Music Reporter|date=June 9, 2016}}</ref>
+| editing              =  {{plainlist|
+* David Burrows
+* [[Matt Villa]]
+* John Venzon
+}}
+| distributor          = [[Warner Bros.|Warner Bros. Pictures]]<ref name=insight>{{cite web|url=http://www.varietyinsight.com/print_featurefilm_releases.php|title=Film releases|work=[[Variety Insight]]|accessdate=February 9, 2017}}</ref>
+| released             = {{film date|2017|1|29|[[Dublin]]|2017|2|9|Denmark|2017|2|10|United States|2017|3|30|Australia|ref1=<ref name=RTEWinPassPremiere />}}
+| runtime              = 104 minutes<!-- Theatrical runtime: 104:23 --><ref>{{cite web | url=http://www.bbfc.co.uk/releases/lego-batman-movie-film-0 | title=''The LEGO Batman Movie'' (U) | work=[[British Board of Film Classification]] | date=January 13, 2017 | accessdate=January 13, 2017}}</ref>
+| country              = {{ubl|United States|Denmark|Australia}}
+| language             = English
+| production companies = {{plainlist|
+* [[Warner Bros. Animation|Warner Animation Group]]<ref name="VarietyReview" />
+* [[DC Entertainment]]<ref name="VarietyReview" />
+* [[RatPac-Dune Entertainment]]<ref name="VarietyReview" />
+* [[The Lego Group|Lego System A/S]]<ref name="VarietyReview" />
+* [[Vertigo Entertainment]]<ref name="VarietyReview" />
+* [[Animal Logic]]<ref name="VarietyReview" />
+* [[Phil Lord and Christopher Miller|Lord Miller Productions]]<ref name="VarietyReview" />
+}}
+| budget               = $80 million<ref name="Variety">{{cite news|last1=Lang|first1=Brent|title=Box Office: ‘Fifty Shades Darker’ No Match for ‘The Lego Batman Movie’|url=http://variety.com/2017/film/news/box-office-fifty-shades-darker-lego-batman-movie-1201980505/|accessdate=February 8, 2017|work=Variety|date=February 7, 2017}}</ref><ref name=BOM/>
+| gross                = $307.3 million<ref name="BOM">{{cite web |url=http://www.boxofficemojo.com/movies/?id=lego2.htm |title=The Lego Batman Movie (2017) |website=Box Office Mojo |accessdate=April 24, 2017}}</ref>
+}}

--- a/test/the-lego-batman-movie-spec.js
+++ b/test/the-lego-batman-movie-spec.js
@@ -1,0 +1,13 @@
+require('should');
+import fs from 'fs';
+import parse from '../index';
+
+describe('Should Parse The Lego Batman Movie\'s Information', () => {
+  const source = fs.readFileSync('./data/the-lego-batman-movie.txt', 'utf8');
+  const properties = parse(source, { simplifyDataValues: false });
+  it('country', () => {
+    properties.country.should.be.an.Array();
+    properties.country.length.should.equal(3);
+    properties.country.should.containEql('Denmark');
+  });
+});


### PR DESCRIPTION
This adds support for the **unbulleted list** template: https://en.wikipedia.org/wiki/Template:Unbulleted_list

I added it to the dataTypes array before `other` even though it's a list because it's used as a one-liner, and so was being captured by the regex for `other` when grouped with the other list types.