### PR TITLE
Fixes: "birth date" can be lowercase, months incorrect

### DIFF
--- a/data-types/birthDates.js
+++ b/data-types/birthDates.js
@@ -1,4 +1,4 @@
-const birthDateGlobalPattern = /\{\{Birth\sdate([^\}\}]+)\}\}/g;
+const birthDateGlobalPattern = /\{\{birth\sdate([^\}\}]+)\}\}/ig;
 const birthDatePattern = /(\d+)\|(\d+)\|(\d+)/;
 
 const millisInYear = 1000 * 60 * 60 * 24 * 365;
@@ -8,7 +8,7 @@ export default {
   parsePattern: birthDatePattern,
   parse: results => {
     const [, year, month, day] = results;
-    const date = new Date(year, month, day);
+    const date = new Date(year, month-1, day);
     const age = Math.floor((Date.now() - +date) / millisInYear);
     return {
       date,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infobox-parser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Parse Wikipedia Infobox Source",
   "main": "build/bundle.min.js",
   "scripts": {

--- a/test/queen-spec.js
+++ b/test/queen-spec.js
@@ -47,6 +47,9 @@ describe('Should Parse Queen\'s Information', () => {
     // Will just update this every year :)
     properties.birthDate.should.have.property('age', 91);
     properties.birthDate.date.should.be.instanceOf(Date);
+    properties.birthDate.date.getFullYear().should.equal(1926);
+    properties.birthDate.date.getMonth().should.equal(3);
+    properties.birthDate.date.getDate().should.equal(21);
   });
   it('signature', () => {
     properties.should.have.property('signature', 'Elizabeth II signature 1952.svg');


### PR DESCRIPTION
Fixes for a couple of issues around processing birthdates.

- Some entries use the "birth date" rather than "Birth date" so made the regex case insensitive.
- Wikipedia months count from 1-12 whereas Javascript months are 0 offset. So need to subtract 1 from the month when creating the Date object

Added a couple of extra tests in Queen for the second issue