### PR TITLE
Replace nowrap template with its content

### DIFF
--- a/test/batman-spec.js
+++ b/test/batman-spec.js
@@ -27,4 +27,9 @@ describe('Should Parse Batman\'s Information', () => {
     properties.general.powers.should.containEql('Expert detective');
     properties.general.powers.should.containEql('Genius-level intellect');
   });
+  it('creators', () => {
+    properties.general.creators.should.containEql('Bill Finger <small>(developer)</small>');
+    properties.general.creators.should.containEql('Bob Kane <small>(concept)</small>');
+    properties.general.creators.should.not.containEql('Bill Finger <small>nowrap</small>');
+  });
 });

--- a/test/beastie-boys-spec.js
+++ b/test/beastie-boys-spec.js
@@ -17,6 +17,8 @@ describe('Should Parse Beastie Boys\'s Information', () => {
   it('genre', () => {
     properties.general.genre.should.containEql('Hip hop music');
     properties.general.genre.should.containEql('rap rock');
+    properties.general.genre.should.containEql('alternative hip hop');
+    properties.general.genre.should.not.containEql('nowrap');
   });
   it('label', () => {
     properties.general.label.should.containEql('Rat Cage Records');

--- a/test/fiorentina-spec.js
+++ b/test/fiorentina-spec.js
@@ -8,4 +8,7 @@ describe('Should Parse Fiorentina', () => {
   it('main image', () => {
     properties.general.should.have.property('image', 'File:ACF Fiorentina 2.svg');
   });
+  it.skip('owner', () => {
+    properties.general.should.not.have.property('owner', undefined);
+  });
 });

--- a/test/freddie-mercury-spec.js
+++ b/test/freddie-mercury-spec.js
@@ -20,4 +20,9 @@ describe('Should Parse Freddie Mercury\'s Information', () => {
   it('associatedActs', () => {
     properties.general.associatedActs.should.containEql('Queen (band)');
   });
+  it('occupation', () => {
+    properties.general.occupation.should.containEql('Singer-songwriter');
+    properties.general.occupation.should.containEql('record producer');
+    properties.general.occupation.should.not.containEql('nowrap');
+  });
 });

--- a/test/queen-spec.js
+++ b/test/queen-spec.js
@@ -54,4 +54,7 @@ describe('Should Parse Queen\'s Information', () => {
   it('signature', () => {
     properties.general.should.have.property('signature', 'Elizabeth II signature 1952.svg');
   });
+  it.skip('reg-type', () => {
+    properties.general.should.have.property('reg-type', 'Prime Ministers');
+  });
 });

--- a/util/cleanSource.js
+++ b/util/cleanSource.js
@@ -14,6 +14,8 @@ export default function cleanSource(source) {
     .replace(/−/g, '-')
     .replace(/<\/sup>/g, '')
     .replace(/<ref(\s\w+=[^>]+)?\s?\/>/g, '')
+    // Replace nowrap template with its content
+    .replace(/\{\{\s*nowrap\s*\|([^\n\}]+)\}\}/g, "$1")
     // HTML comments
     .replace(/<!--([\s\S]*?)-->/g, '')
     .replace(/&nbsp;/g, ' ')


### PR DESCRIPTION
While trying infobox-parser with another wikitext input, I found some cases where current test data is parsed incorrectly when there is a `nowrap` template around. The [nowrap template](https://en.wikipedia.org/wiki/Template:Nowrap) instructs to prevent line breaks in its content, this PR replaces nowrap templates with their content in the `cleanSource` step, and adds assertions for every case of `nowrap` in the test data. I have marked some of the tests with `skip` to indicate that there is also some other problem that prevents these cases from being parsed correctly.